### PR TITLE
Document design sketch reference in specs

### DIFF
--- a/docs/assets/README.md
+++ b/docs/assets/README.md
@@ -1,0 +1,8 @@
+# Space Ball Asset Catalogue
+
+Store shared reference imagery and concept sketches in this directory so they can be linked from the behavioural specs.
+
+## Adding a New Visual Reference
+- Save the asset using a descriptive snake_case filename (for example, `space_ball_sketch.png`).
+- Commit binary images directly to the repository; avoid external links so the specs remain self-contained.
+- Reference the asset path from the relevant `.feature` file using a comment or Background note to make the association explicit.

--- a/docs/design_reference.md
+++ b/docs/design_reference.md
@@ -1,0 +1,9 @@
+# Space Ball Design Reference
+
+The sketch titled **Space Ball Concept** (store it at `docs/assets/space_ball_sketch.png`) illustrates the mobile portrait layout for the plinko-style scoring board. Use this image as the canonical visual reference when updating gameplay or UI specs.
+
+- Mercury, Earth, Mars, Jupiter, Saturn, and Pluto scoring pockets are aligned vertically beneath the apex of the rails.
+- Score values increase as the ball drops lower, with Pluto representing the highest-value goal at the bottom center.
+- The player's thumbs pinch the rails near the base, reinforcing the touch-control scenarios described in `docs/specs/touch_controls.feature`.
+
+When refining behaviour-driven specs, add a comment noting this asset so future contributors understand the intended arrangement.

--- a/docs/specs/core_gameplay.feature
+++ b/docs/specs/core_gameplay.feature
@@ -1,4 +1,5 @@
 Feature: Core Space Ball gameplay loop
+  # Visual reference: docs/assets/space_ball_sketch.png (see docs/design_reference.md for context)
   As a mobile player
   I want the ball to respond to gravity and rail spacing
   So that I can control its descent and score points by dropping it intentionally


### PR DESCRIPTION
## Summary
- add documentation describing where to store the Space Ball concept sketch and how to reference it in specs
- annotate the core gameplay feature file with a comment pointing to the shared visual reference

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e213fefa04833393f872997dbbf911