### PR TITLE
Clarify core gameplay spec for rail interactions

### DIFF
--- a/docs/specs/core_gameplay.feature
+++ b/docs/specs/core_gameplay.feature
@@ -1,23 +1,30 @@
 Feature: Core Space Ball gameplay loop
   # Visual reference: docs/assets/space_ball_sketch.png (see docs/design_reference.md for context)
   As a mobile player
-  I want the ball to respond to gravity and rail spacing
-  So that I can control its descent and score points by dropping it intentionally
+  I want the ball to react predictably to the rail spacing
+  So that I can intentionally guide it toward the scoring zone
 
   Background:
     Given the Space Ball game is loaded on a mobile device in portrait mode
-    And a metal ball rests at the top apex between two rails with a configurable tilt
+    And a metal ball rests at the apex between two slightly tilted rails
 
-  Scenario: Ball remains at the apex when rails are aligned
+  Scenario: Ball stays parked when the rails match
     When the player keeps both rails aligned and stationary
     Then the ball should remain balanced at the apex without sliding
 
-  Scenario: Ball accelerates downward when rails separate
+  Scenario: Ball speeds up while the rails open
     When the player widens the gap between the rails gradually
-    Then the ball should move downward along the rails due to gravity
-    And the ball's velocity should increase smoothly as it descends
+    Then the ball should move downward along the rails because of gravity
+    And the ball's speed should increase smoothly as it descends
 
-  Scenario: Scoring when the ball exits the rails at the base
+  Scenario: Ball climbs back when the rails close
+    Given the ball has started descending between the rails
+    When the player narrows the gap until the rails nearly touch
+    Then the ball should slow down as the rails close
+    And once the ball loses forward speed it should reverse direction
+    And the ball should travel upward to its resting position at the apex because the upper section of the rails sits slightly lower than the base
+
+  Scenario: Ball scores after exiting the rails
     Given the player has widened the rails enough for the ball to reach the base
     When the gap becomes wider than the ball's diameter at the exit point
     Then the ball should fall through the opening into the scoring zone


### PR DESCRIPTION
## Summary
- rewrite the core gameplay feature for clearer, player-focused language
- add a scenario covering the ball climbing back to the apex when the rails close
- retain the scoring scenario while aligning its wording with the revised tone

## Testing
- Not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68f39d02d200833391ee02f5218c7675