### PR TITLE
Allow ball to leave the start gate

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -216,7 +216,9 @@ function updatePhysics(dt) {
 
   if (ball.state === "ready") {
     const openingThreshold = geometry.ballRadius * 0.6;
-    if (gap > openingThreshold) {
+    const atStartGate = ball.y <= 0.02;
+
+    if (gap > openingThreshold || atStartGate) {
       ball.velocity += accelDown * dtSeconds;
     } else {
       // Rails squeezing - encourage the ball to travel upward


### PR DESCRIPTION
## Summary
- prevent the squeeze logic from cancelling gravity while the ball is still at the starting gate so it can begin to roll

## Testing
- npm test *(fails: npm is not installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_6900e0804454833389ac3944808c3b3d