### PR TITLE
Adjust touch pad spacing for footer controls

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -122,13 +122,14 @@ body {
 }
 
 .touch-zones {
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: 12px;
+  display: flex;
+  justify-content: space-between;
+  gap: 0;
 }
 
 .touch-pad {
   position: relative;
+  flex: 0 0 33.333%;
   border: none;
   border-radius: 20px;
   background: rgba(20, 35, 66, 0.9);


### PR DESCRIPTION
## Summary
- update the footer touch zone layout to space the left and right pads across thirds with an empty middle column
- keep the existing control behaviour by maintaining the same pointer handling logic

## Testing
- not run (UI-only change)

## Scenario Coverage
- No updates required; existing `touch_controls.feature` scenarios continue to apply


------
https://chatgpt.com/codex/tasks/task_e_6900ff8608388333aa1119253f3d23c8