### PR TITLE
Add 3D rail physics with Babylon.js

### DIFF
--- a/docs/specs/core_gameplay.feature
+++ b/docs/specs/core_gameplay.feature
@@ -14,7 +14,7 @@ Feature: Core Space Ball gameplay loop
 
   Scenario: Ball speeds up while the rails open
     When the player widens the gap between the rails gradually
-    Then the ball should move downward along the rails because of gravity
+    Then the ball should move downward along the rails in the X-Y plane because of gravity
     And the ball's speed should increase smoothly as it descends
 
   Scenario: Ball climbs back when the rails close
@@ -27,6 +27,6 @@ Feature: Core Space Ball gameplay loop
   Scenario: Ball scores after exiting the rails
     Given the player has widened the rails enough for the ball to reach the base
     When the gap becomes wider than the ball's diameter at the exit point
-    Then the ball should fall through the opening into the scoring zone
+    Then the ball should fall straight down along the Z axis into the scoring zone below the rails
     And the player's score should increase by one
     And the ball should reset to the apex for the next attempt within two seconds


### PR DESCRIPTION
## Summary
- replace the 2D canvas playfield with a Babylon.js scene that renders the rails and ball in 3D
- update the physics loop so the ball moves across the rails in the X-Y plane and drops along the Z axis once the exit gap opens
- clarify the core gameplay specification to describe the new planar motion and vertical drop

## Scenarios
- Core gameplay: Ball speeds up while the rails open
- Core gameplay: Ball scores after exiting the rails

## Testing
- npm test *(fails: jest not found in environment)*


------
https://chatgpt.com/codex/tasks/task_e_690101afd29483339b805bb6c130b4ba