### PR TITLE
Fix camera orientation and add tuning controls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/src/index.html
+++ b/src/index.html
@@ -27,10 +27,12 @@
 
       <section class="playfield-wrapper">
         <canvas id="playfield" width="360" height="640" aria-label="Space Ball playfield"></canvas>
-        <aside class="tilt-control" aria-label="Tilt control">
-          <label for="tiltSlider" class="tilt-control__label">Rail Tilt</label>
+        <aside class="control-panel" aria-label="Game controls">
+          <section class="control-panel__card control-panel__card--tilt" aria-label="Tilt control">
+            <label for="tiltSlider" class="tilt-control__label">Rail Tilt</label>
             <input
               id="tiltSlider"
+              class="tilt-control__slider"
               type="range"
               min="0"
               max="100"
@@ -41,10 +43,63 @@
               aria-label="Adjust rail tilt"
               orient="vertical"
             />
-          <div class="tilt-control__ticks">
-            <span>steep</span>
-            <span>gentle</span>
-          </div>
+            <div class="tilt-control__ticks">
+              <span>steep</span>
+              <span>gentle</span>
+            </div>
+          </section>
+
+          <section class="control-panel__card control-panel__card--camera" aria-label="Camera tuning">
+            <h2 class="control-panel__title">Camera</h2>
+            <div class="camera-tuner__group">
+              <label for="cameraAlphaSlider" class="camera-tuner__label">
+                Orbit
+                <span id="cameraAlphaReadout" class="camera-tuner__value">20°</span>
+              </label>
+              <input
+                id="cameraAlphaSlider"
+                class="camera-tuner__slider"
+                type="range"
+                min="0"
+                max="360"
+                step="1"
+                value="20"
+                aria-label="Adjust camera orbit"
+              />
+            </div>
+            <div class="camera-tuner__group">
+              <label for="cameraBetaSlider" class="camera-tuner__label">
+                Pitch
+                <span id="cameraBetaReadout" class="camera-tuner__value">60°</span>
+              </label>
+              <input
+                id="cameraBetaSlider"
+                class="camera-tuner__slider"
+                type="range"
+                min="35"
+                max="110"
+                step="1"
+                value="60"
+                aria-label="Adjust camera pitch"
+              />
+            </div>
+            <div class="camera-tuner__group">
+              <label for="cameraZoomSlider" class="camera-tuner__label">
+                Zoom
+                <span id="cameraZoomReadout" class="camera-tuner__value">12.0</span>
+              </label>
+              <input
+                id="cameraZoomSlider"
+                class="camera-tuner__slider"
+                type="range"
+                min="9"
+                max="16"
+                step="0.1"
+                value="12"
+                aria-label="Adjust camera zoom"
+              />
+            </div>
+          </section>
         </aside>
       </section>
 

--- a/src/style.css
+++ b/src/style.css
@@ -72,7 +72,13 @@ body {
   box-shadow: inset 0 12px 40px rgba(0, 0, 0, 0.45);
 }
 
-.tilt-control {
+.control-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.control-panel__card {
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -83,12 +89,26 @@ body {
   box-shadow: 0 8px 30px rgba(0, 0, 0, 0.3);
 }
 
+.control-panel__card--camera {
+  align-items: stretch;
+  gap: 16px;
+}
+
+.control-panel__title {
+  width: 100%;
+  margin: 0;
+  font-size: 0.9rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  text-align: left;
+}
+
 .tilt-control__label {
   font-size: 0.85rem;
   letter-spacing: 0.04em;
 }
 
-.tilt-control input[type="range"] {
+.tilt-control__slider {
   writing-mode: bt-lr;
   -webkit-appearance: slider-vertical;
   width: 24px;
@@ -96,7 +116,7 @@ body {
   background: transparent;
 }
 
-.tilt-control input[type="range"]::-webkit-slider-thumb {
+.tilt-control__slider::-webkit-slider-thumb {
   -webkit-appearance: none;
   height: 36px;
   width: 24px;
@@ -106,10 +126,24 @@ body {
   box-shadow: 0 4px 16px rgba(53, 197, 255, 0.5);
 }
 
-.tilt-control input[type="range"]::-webkit-slider-runnable-track {
+.tilt-control__slider::-moz-range-thumb {
+  height: 36px;
+  width: 24px;
+  border-radius: 8px;
+  background: var(--accent);
+  border: none;
+  box-shadow: 0 4px 16px rgba(53, 197, 255, 0.5);
+}
+
+.tilt-control__slider::-webkit-slider-runnable-track {
   background: linear-gradient(180deg, var(--accent) 0%, rgba(255, 255, 255, 0.3) 100%);
   border-radius: 12px;
   width: 6px;
+}
+
+.tilt-control__slider::-moz-range-track {
+  background: linear-gradient(180deg, var(--accent) 0%, rgba(255, 255, 255, 0.3) 100%);
+  border-radius: 12px;
 }
 
 .tilt-control__ticks {
@@ -119,6 +153,64 @@ body {
   font-size: 0.7rem;
   opacity: 0.6;
   text-transform: uppercase;
+}
+
+.camera-tuner__group {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.camera-tuner__label {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-size: 0.75rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  opacity: 0.7;
+}
+
+.camera-tuner__value {
+  font-size: 0.85rem;
+  font-weight: 600;
+  opacity: 0.9;
+}
+
+.camera-tuner__slider {
+  -webkit-appearance: none;
+  width: 100%;
+  height: 6px;
+  border-radius: 999px;
+  background: linear-gradient(90deg, rgba(255, 255, 255, 0.4) 0%, rgba(53, 197, 255, 0.35) 100%);
+  outline: none;
+}
+
+.camera-tuner__slider::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: var(--accent);
+  box-shadow: 0 2px 10px rgba(53, 197, 255, 0.45);
+  border: none;
+}
+
+.camera-tuner__slider::-moz-range-track {
+  width: 100%;
+  height: 6px;
+  border-radius: 999px;
+  background: linear-gradient(90deg, rgba(255, 255, 255, 0.4) 0%, rgba(53, 197, 255, 0.35) 100%);
+}
+
+.camera-tuner__slider::-moz-range-thumb {
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: var(--accent);
+  border: none;
+  box-shadow: 0 2px 10px rgba(53, 197, 255, 0.45);
 }
 
 .touch-zones {
@@ -174,7 +266,7 @@ body {
     gap: 10px;
   }
 
-  .tilt-control input[type="range"] {
+  .tilt-control__slider {
     height: 220px;
   }
 }


### PR DESCRIPTION
## Summary
- reposition the BabylonJS camera above the board and expose tuning sliders for orbit, pitch, and zoom
- refresh the control panel UI to house both tilt and camera controls with updated styling
- ignore local node_modules in version control

## Testing
- npm test *(fails: jest not found in PATH)*

------
https://chatgpt.com/codex/tasks/task_e_690118c5b9b883339e9b3419ce06e98a