### PR TITLE
Fix scoring pocket positions

### DIFF
--- a/docs/specs/core_gameplay.feature
+++ b/docs/specs/core_gameplay.feature
@@ -30,3 +30,8 @@ Feature: Core Space Ball gameplay loop
     Then the ball should fall straight down along the Z axis into the scoring zone below the rails
     And the player's score should increase by one
     And the ball should reset to the apex for the next attempt within two seconds
+
+  Scenario: Scoring pockets descend beneath the rail exit
+    When the scoring pockets are visible under the rails
+    Then each pocket should sit lower than the one above it
+    And Pluto should be the lowest and widest target

--- a/src/control-logic.js
+++ b/src/control-logic.js
@@ -40,19 +40,19 @@ export function getRailX(geometry, state, yNorm, side) {
 
 export function createPocketLayouts(geometry) {
   const { centerX, bottomY, pocketRadius } = geometry;
-  const baseY = bottomY + pocketRadius * 1.6;
+  const baseY = bottomY - pocketRadius * 1.6;
   const spacing = pocketRadius * 2.4;
 
   return [
     { name: "Mercury", radius: pocketRadius, y: baseY, highlight: false },
-    { name: "Earth", radius: pocketRadius, y: baseY + spacing, highlight: false },
-    { name: "Mars", radius: pocketRadius, y: baseY + spacing * 2, highlight: false },
-    { name: "Jupiter", radius: pocketRadius, y: baseY + spacing * 3, highlight: false },
-    { name: "Saturn", radius: pocketRadius, y: baseY + spacing * 4, highlight: false },
+    { name: "Earth", radius: pocketRadius, y: baseY - spacing, highlight: false },
+    { name: "Mars", radius: pocketRadius, y: baseY - spacing * 2, highlight: false },
+    { name: "Jupiter", radius: pocketRadius, y: baseY - spacing * 3, highlight: false },
+    { name: "Saturn", radius: pocketRadius, y: baseY - spacing * 4, highlight: false },
     {
       name: "Pluto",
       radius: pocketRadius + 6,
-      y: baseY + spacing * 5 + pocketRadius * 0.9,
+      y: baseY - spacing * 5 - pocketRadius * 0.9,
       highlight: true,
     },
   ].map((pocket) => ({

--- a/src/main.js
+++ b/src/main.js
@@ -4,6 +4,7 @@ import {
   sliderValueToTilt,
   tiltToAcceleration,
   getRailX,
+  createPocketLayouts,
 } from "./control-logic.js";
 
 import {
@@ -424,7 +425,7 @@ const debugInterface = {
     },
   },
   getPocketLayout() {
-    return [];
+    return createPocketLayouts(geometry);
   },
 };
 

--- a/tests/touch-controls.spec.js
+++ b/tests/touch-controls.spec.js
@@ -86,6 +86,6 @@ test("scoring pockets stay centered under the rails", async ({ page }) => {
   ]);
 
   for (let i = 1; i < pockets.length; i += 1) {
-    expect(pockets[i].y).toBeGreaterThan(pockets[i - 1].y);
+    expect(pockets[i].y).toBeLessThan(pockets[i - 1].y);
   }
 });

--- a/tests/unit/control-logic.test.js
+++ b/tests/unit/control-logic.test.js
@@ -68,7 +68,7 @@ test('pocket layouts stay centred and ordered', () => {
   const names = pockets.map((pocket) => pocket.name);
   assert.deepEqual(names, ['Mercury', 'Earth', 'Mars', 'Jupiter', 'Saturn', 'Pluto']);
   for (let i = 1; i < pockets.length; i += 1) {
-    assert.ok(pockets[i].y > pockets[i - 1].y);
+    assert.ok(pockets[i].y < pockets[i - 1].y);
   }
   const highlighted = pockets.filter((pocket) => pocket.highlight === true);
   assert.equal(highlighted.length, 1);


### PR DESCRIPTION
## Summary
- ensure the scoring pocket layout sits beneath the rail exit by correcting the vertical offsets
- expose the generated pocket layout through the debug interface for UI validation
- align specs and automated checks with the descending pocket order

## Testing
- node --test tests/unit/control-logic.test.js


------
https://chatgpt.com/codex/tasks/task_e_690130c4009483339fb1867acd3e35ac