### PR TITLE
Fix board tilt orientation

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -261,7 +261,8 @@ function updateBoardTilt() {
   );
   const minAngle = Math.PI / 3.1;
   const maxAngle = Math.PI / 2.2;
-  boardPivot.rotation.x = minAngle + (maxAngle - minAngle) * normalizedTilt;
+  const tiltAngle = minAngle + (maxAngle - minAngle) * normalizedTilt;
+  boardPivot.rotation.x = -tiltAngle;
 }
 
 updateBoardTilt();


### PR DESCRIPTION
## Summary
- reverse the board pivot's tilt so the rails and ball align with gravity

## Testing
- npm test -- --runTestsByPath tests/control-logic.test.js *(fails: Jest configuration rejects extensionsToTreatAsEsm setting)*

------
https://chatgpt.com/codex/tasks/task_e_6901331243548333a6064dd705a4eb26