### PR TITLE
Clarify rod-ball physics behaviour in specs

### DIFF
--- a/docs/specs/spaceball_physics.feature
+++ b/docs/specs/spaceball_physics.feature
@@ -1,58 +1,55 @@
-Feature: SpaceBall orbital physics model
-  The mechanical SpaceBall toy is reimagined with orbital mechanics, requiring precise force pulses
-  and magnetically assisted capture to deliver deterministic skill-based gameplay.
-  # Visual references
-  # - Neutral drift: docs/assets/spaceball_state_starting_position.jpeg
-  # - Capture phase: docs/assets/spaceball_state_goal_capture.jpeg
+Feature: Realistic rod-ball mechanical physics
+  The Babylon.js simulation reproduces the authentic Space Ball toy behaviour:
+  a steel ball perched on two controllable rods slides downward under gravity,
+  gains kinetic energy as the rods open, and eventually drops if the separation
+  exceeds the ball's diameter.
 
   Background:
-    Given the neutral drift diagram is available at "docs/assets/spaceball_state_starting_position.jpeg"
-    And the capture phase diagram is available at "docs/assets/spaceball_state_goal_capture.jpeg"
+    Given a steel ball of mass 0.18 kilograms and diameter 0.038 meters
+    And two rods form a V-shaped cradle with controllable separation distance
+    And the rods are aligned along the Y axis with the ball's downward travel measured along Y
 
-  Scenario: Neutral drift remains stable without input
-    Given the spaceball mass is 0.18 kilograms
-    And the orbital lane curvature keeps centripetal acceleration under 0.4 meters per second squared
-    When no thrust impulse is applied for 5 seconds
-    Then the ball should maintain a tangential velocity between 0.45 and 0.55 meters per second
-    And the radial offset from the lane midline should stay within 0.02 meters
+  Scenario: Ball remains supported when rods are closed and level
+    Given the rod separation is 0.030 meters (less than the ball diameter)
+    And the rods are level with zero slope
+    When the simulation advances for 3 seconds with gravity enabled
+    Then the ball should remain in static equilibrium without translating along the Y axis
+    And its vertical position should not change by more than 0.001 meters
 
-  Scenario Outline: Pulse thrusters adjust tangential velocity predictably
-    Given the pilot applies a thrust pulse lasting <duration> milliseconds
-    And the thruster delivers 0.9 newtons of force while active
-    When the simulation integrates the pulse over the timestep
-    Then the tangential velocity should change by <delta_v> meters per second
-    And the cumulative kinetic energy delta must match within 5 percent of 1/2 * m * (delta_v^2)
+  Scenario Outline: Opening rods induces downhill motion from geometric drop
+    Given the rods are opened to a separation of <separation> meters at the front and 0.030 meters at the back
+    And each rod is modelled as a kinematic PhysicsShapeCylinder aligned with the Y axis
+    When the simulation runs with gravity for 2 seconds at a 240 Hz physics timestep and 480 Hz substep
+    Then the ball should translate downward along Y by at least <min_descent> meters
+    And the ball's kinetic energy should increase relative to the starting frame
 
     Examples:
-      | duration | delta_v |
-      | 050      | 0.25    |
-      | 100      | 0.50    |
-      | 150      | 0.75    |
+      | separation | min_descent |
+      | 0.032      | 0.015       |
+      | 0.034      | 0.028       |
+      | 0.036      | 0.045       |
 
-  Scenario: Magnetic gate captures the ball when residual speed is low
-    Given the capture gate applies a magnetic braking field of 1.2 newtons opposite travel direction
-    And the capture zone is 0.3 meters long
-    When the ball enters the capture zone below 0.6 meters per second
-    Then the ball should decelerate to a stop before exiting the zone
-    And the kinetic energy dissipated should be logged for scoring feedback
+  Scenario: Closing rods mid-descent increases friction but preserves inertia
+    Given the rods are opened to 0.035 meters allowing the ball to accelerate for 1 second
+    When the rods are closed back to 0.031 meters over 0.4 seconds while the simulation continues
+    Then the ball's linear speed along Y should decrease by at least 25 percent during closure
+    And the ball should continue moving downward along Y without reversing direction
 
-  Scenario: Bounce response when the ball strikes the gate too fast
-    Given the ball approaches the capture gate at 0.9 meters per second
-    And the gate collision coefficient of restitution is 0.35
-    When the ball impacts the gate plating
-    Then the post-collision speed should resolve to approximately 0.32 meters per second in the opposite direction
-    And the rebound vector should align within 3 degrees of the incoming trajectory mirrored across the gate normal
+  Scenario: Excessive opening causes the ball to drop through the rods
+    Given the rods are opened uniformly to 0.040 meters (greater than the ball diameter)
+    When the simulation advances for up to 1.5 seconds
+    Then the ball's center should fall below the rod plane, indicating a drop event
+    And the drop event should record the ball's Y position for scoring
 
-  Scenario: JavaScript implementation guidelines
-    Given the simulation runs inside a `SpaceballSimulation` module under `src/physics/`
-    And the update loop uses a fixed 120 Hz tick with semi-implicit Euler integration
-    When thrust inputs are received from the control layer
-    Then the module should update velocity and position vectors using SI units (meters, seconds, kilograms)
-    And it should expose collision events so the UI can trigger capture effects
+  Scenario: Physics integration settings for smooth motion
+    Given the Babylon.js scene uses a physics engine plugin compatible with setTimeStep
+    When the simulation initialises the physics engine
+    Then `scene.getPhysicsEngine().setTimeStep(1/240)` should be applied
+    And `physicsPlugin.setSubTimeStep(1/480)` should be applied for solver accuracy
+    And rod impostors should remain kinematic so player inputs directly control their separation
 
-  Scenario: Physics framework recommendations for the web client
-    Given the team needs rigid body dynamics with constraint solving and collision detection
-    When selecting supporting libraries for the Babylon.js scene graph mandated by the project
-    Then prefer integrating `cannon-es` through the Babylon.js physics plugin for lightweight rigid bodies
-    And consider `ammo.js` when higher stability is required for stacked interactions
-    And prototype impulse-only behaviour with the built-in Babylon.js `PhysicsImpostor` before adding external engines
+  Scenario: Scoring and telemetry when the ball drops
+    Given the simulation tracks the ball's cumulative Y displacement from its starting position
+    When the drop event triggers because the ball's center falls below the rod plane
+    Then the score should equal the total Y displacement travelled before the drop
+    And the event payload should include the final separation distance of the rods


### PR DESCRIPTION
## Summary
- replace the orbital-focused physics feature with a Babylon.js rod-ball mechanics specification
- document expected gravity-driven descent, friction changes, solver settings, and scoring for the mechanical game

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_6901f9c6af688333b6a4caa14e623b80