### PR TITLE
Fix Ammo typed module import paths

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -510,8 +510,8 @@ bindTouchPad(rightPad, "right");
 
 function loadAmmoModule() {
   const typedModules = [
-    "https://cdn.jsdelivr.net/npm/ammojs-typed@1.0.6/ammo.wasm.js",
-    "https://cdn.jsdelivr.net/npm/ammojs-typed@1.0.6/ammo.js",
+    "https://cdn.jsdelivr.net/npm/ammojs-typed@1.0.6/ammo/ammo.wasm.js",
+    "https://cdn.jsdelivr.net/npm/ammojs-typed@1.0.6/ammo/ammo.js",
   ];
 
   const tryTypedModule = (index = 0) => {


### PR DESCRIPTION
## Summary
- fix the Ammo typed module CDN URLs so the physics engine can load correctly

## Testing
- not run

## Scenarios
- spaceball_physics.feature


------
https://chatgpt.com/codex/tasks/task_e_6902026711cc8333b0cb7448cc92a0cb