### PR TITLE
Fix Ammo typed CDN path

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -510,8 +510,8 @@ bindTouchPad(rightPad, "right");
 
 function loadAmmoModule() {
   const typedModules = [
-    "https://cdn.jsdelivr.net/npm/ammojs-typed@1.0.6/ammo/ammo.wasm.js",
-    "https://cdn.jsdelivr.net/npm/ammojs-typed@1.0.6/ammo/ammo.js",
+    "https://cdn.jsdelivr.net/npm/ammojs-typed@1.0.6/builds/ammo.wasm.js",
+    "https://cdn.jsdelivr.net/npm/ammojs-typed@1.0.6/builds/ammo.js",
   ];
 
   const tryTypedModule = (index = 0) => {


### PR DESCRIPTION
## Summary
- update the Ammo typed module CDN paths to point at the builds directory so the modules can be resolved

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_690203cc49388333bda954327de68df2