### PR TITLE
Fix Babylon core import path for GitHub Pages

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -23,7 +23,7 @@ import {
   PhysicsMotionType,
   PhysicsShapeType,
   AmmoJSPlugin,
-} from "https://cdn.jsdelivr.net/npm/@babylonjs/core@7.34.0/+esm";
+} from "https://cdn.jsdelivr.net/npm/@babylonjs/core@7.34.0/index.js";
 import "https://cdn.jsdelivr.net/npm/@babylonjs/core@7.34.0/Meshes/Builders/tubeBuilder.js";
 import "https://cdn.jsdelivr.net/npm/@babylonjs/core@7.34.0/Meshes/Builders/sphereBuilder.js";
 import "https://cdn.jsdelivr.net/npm/@babylonjs/core@7.34.0/Materials/standardMaterial.js";


### PR DESCRIPTION
## Summary
- update the Babylon.js core import in src/main.js to use the correct index.js ESM entry point so module loads on GitHub Pages

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_69023269a4608333940088fb47dc2add