### PR TITLE
Defer main bootstrap until external engines ready

### DIFF
--- a/index.html
+++ b/index.html
@@ -130,8 +130,22 @@
       </footer>
     </main>
     <!-- Load Babylon and Ammo before main.js -->
-    <script src="https://cdn.babylonjs.com/babylon.js"></script>
-    <script src="https://cdn.babylonjs.com/ammo.js"></script>
-    <script src="src/main.js"></script>
+    <script src="https://cdn.babylonjs.com/babylon.js" defer></script>
+    <script src="https://cdn.babylonjs.com/ammo.js" defer></script>
+    <script>
+      // Wait for both Babylon and Ammo to be available before loading main.js
+      function whenReady(cb) {
+        const check = () => {
+          if (window.BABYLON && window.Ammo) cb();
+          else setTimeout(check, 50);
+        };
+        check();
+      }
+      whenReady(() => {
+        const s = document.createElement('script');
+        s.src = 'src/main.js?v=' + Date.now(); // cache-bust
+        document.body.appendChild(s);
+      });
+    </script>
   </body>
 </html>

--- a/src/main.js
+++ b/src/main.js
@@ -6,6 +6,13 @@ const scriptLoadResults = ['babylon.js', 'ammo.js'].map((src) => {
 });
 console.log('Document readyState:', document.readyState);
 
+if (document.readyState === 'loading') {
+  console.log('⏳ Waiting for DOM ready...');
+  document.addEventListener('DOMContentLoaded', () => {
+    console.log('✅ DOM ready, continuing...');
+  });
+}
+
 const status = document.getElementById('status-bar');
 function logLine(msg) {
   console.log('[SpaceBall]', msg);
@@ -183,10 +190,12 @@ function degToRad(degrees) {
 (async function bootstrap() {
   try {
     await step('Verify Babylon global', async () => {
+      const t0 = performance.now();
       if (typeof window.BABYLON === 'undefined') {
-        throw new Error('BABYLON global missing (babylon.js not loaded)');
+        throw new Error('BABYLON global missing (babylon.js not ready)');
       } else {
-        logLine('✅ Babylon.js successfully detected');
+        const dt = (performance.now() - t0).toFixed(1);
+        logLine(`✅ Babylon.js detected after ${dt}ms`);
       }
     });
 


### PR DESCRIPTION
## Summary
- defer loading of the main game bundle until Babylon.js and Ammo.js are confirmed on the page
- add a DOM ready-state log to highlight when bootstrap waits for the document
- enhance the Babylon verification step with timing-aware logging and clearer error messaging

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_69026d2e9df48333bdb187d35d92fefb