### PR TITLE
Fix debug panel cleanup crash and retune zoom slider

### DIFF
--- a/index.html
+++ b/index.html
@@ -103,16 +103,16 @@
             <div class="camera-tuner__group">
               <label for="cameraZoomSlider" class="camera-tuner__label">
                 Zoom
-                <span id="cameraZoomReadout" class="camera-tuner__value">12.0</span>
+                <span id="cameraZoomReadout" class="camera-tuner__value">1.20</span>
               </label>
               <input
                 id="cameraZoomSlider"
                 class="camera-tuner__slider"
                 type="range"
-                min="9"
-                max="16"
-                step="0.1"
-                value="12"
+                min="0.6"
+                max="2.8"
+                step="0.05"
+                value="1.2"
                 aria-label="Adjust camera zoom"
               />
             </div>

--- a/src/main.js
+++ b/src/main.js
@@ -1,5 +1,6 @@
 // === Early debug helpers ===
 const statusEl = document.getElementById('status-bar');
+let debugPanel;
 function logLine(msg) {
   console.log('[SpaceBall]', msg);
   if (statusEl) {
@@ -89,7 +90,7 @@ if (typeof window.BABYLON === 'undefined') {
 
 const DEBUG_MODE = new URL(location.href).searchParams.has('debug');
 if (DEBUG_MODE) {
-  const debugPanel = document.createElement('div');
+  debugPanel = document.createElement('div');
   debugPanel.style.cssText =
     'position:fixed;top:40px;left:0;width:100%;max-height:35vh;overflow:auto;background:#0b1022;color:#d9e8ff;font-family:monospace;font-size:12px;padding:6px;z-index:9998;';
   document.body.appendChild(debugPanel);
@@ -287,7 +288,7 @@ function degToRad(degrees) {
         scene
       );
       cam.lowerRadiusLimit = Number(cameraZoomSlider.min ?? 0.6);
-      cam.upperRadiusLimit = Number(cameraZoomSlider.max ?? 2.4);
+      cam.upperRadiusLimit = Number(cameraZoomSlider.max ?? 2.8);
       cam.lowerBetaLimit = degToRad(safeLowerBetaDeg);
       cam.upperBetaLimit = degToRad(safeUpperBetaDeg);
       cam.wheelPrecision = 120;
@@ -311,7 +312,7 @@ function degToRad(degrees) {
       const zoom = clamp(
         Number(cameraZoomSlider.value) || 0,
         Number(cameraZoomSlider.min) || 0.6,
-        Number(cameraZoomSlider.max) || 2.4
+        Number(cameraZoomSlider.max) || 2.8
       );
 
       camera.alpha = degToRad(alphaDeg);
@@ -925,7 +926,7 @@ function degToRad(degrees) {
     if (!DEBUG_MODE) {
       setTimeout(() => {
         if (statusEl) statusEl.style.display = 'none';
-        if (dbgEl) dbgEl.style.display = 'none';
+        if (debugPanel) debugPanel.style.display = 'none';
         if (scriptBanner) scriptBanner.style.display = 'none';
       }, 2500);
     } else {


### PR DESCRIPTION
## Summary
- prevent production builds from throwing when the debug panel is not initialised
- retune the camera zoom slider to expose a more useful range and readout precision

## Testing
- npm test

## Scenarios
- camera_controls.feature: Scenario: Updating camera values via sliders

------
https://chatgpt.com/codex/tasks/task_e_690283db08f08333937a24a05ccedc52