### PR TITLE
Set camera controls to midpoint defaults

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -73,39 +73,39 @@
             <div class="camera-tuner__group">
               <label for="cameraAlphaSlider" class="camera-tuner__label">
                 Orbit
-                <span id="cameraAlphaReadout" class="camera-tuner__value">20°</span>
+                <span id="cameraAlphaReadout" class="camera-tuner__value">90°</span>
               </label>
               <input
                 id="cameraAlphaSlider"
                 class="camera-tuner__slider"
                 type="range"
                 min="0"
-                max="360"
+                max="180"
                 step="1"
-                value="20"
+                value="90"
                 aria-label="Adjust camera orbit"
               />
             </div>
             <div class="camera-tuner__group">
               <label for="cameraBetaSlider" class="camera-tuner__label">
                 Pitch
-                <span id="cameraBetaReadout" class="camera-tuner__value">60°</span>
+                <span id="cameraBetaReadout" class="camera-tuner__value">45°</span>
               </label>
               <input
                 id="cameraBetaSlider"
                 class="camera-tuner__slider"
                 type="range"
                 min="0"
-                max="360"
+                max="90"
                 step="1"
-                value="60"
+                value="45"
                 aria-label="Adjust camera pitch"
               />
             </div>
             <div class="camera-tuner__group">
               <label for="cameraZoomSlider" class="camera-tuner__label">
                 Zoom
-                <span id="cameraZoomReadout" class="camera-tuner__value">1.20</span>
+                <span id="cameraZoomReadout" class="camera-tuner__value">1.50</span>
               </label>
               <input
                 id="cameraZoomSlider"
@@ -114,7 +114,7 @@
                 min="0.6"
                 max="2.4"
                 step="0.05"
-                value="1.2"
+                value="1.5"
                 aria-label="Adjust camera zoom"
               />
             </div>

--- a/src/main.js
+++ b/src/main.js
@@ -268,27 +268,36 @@ function degToRad(degrees) {
       if (!cameraAlphaSlider || !cameraBetaSlider || !cameraZoomSlider) {
         throw new Error('Camera controls missing');
       }
+      const alphaRange = {
+        min: Number(cameraAlphaSlider.min ?? 0),
+        max: Number(cameraAlphaSlider.max ?? 360),
+      };
       const betaRange = {
         min: Number(cameraBetaSlider.min ?? 0),
         max: Number(cameraBetaSlider.max ?? 360),
       };
       safeLowerBetaDeg = Math.min(betaRange.min + betaLimitPadding, betaRange.max - betaLimitPadding);
       safeUpperBetaDeg = Math.max(betaRange.min + betaLimitPadding, betaRange.max - betaLimitPadding);
+      const initialAlphaDegrees = clamp(
+        Number(cameraAlphaSlider.value ?? 90) || 0,
+        alphaRange.min,
+        alphaRange.max
+      );
       const initialBetaDegrees = clamp(
-        Number(cameraBetaSlider.value ?? 60) || 0,
+        Number(cameraBetaSlider.value ?? 45) || 0,
         safeLowerBetaDeg,
         safeUpperBetaDeg
       );
       const cam = new ArcRotateCamera(
         'camera',
-        degToRad(cameraAlphaSlider.value ?? 20),
+        degToRad(initialAlphaDegrees),
         degToRad(initialBetaDegrees),
-        Number(cameraZoomSlider.value ?? 1.2),
+        Number(cameraZoomSlider.value ?? 1.5),
         new Vector3(0, -0.05, -0.35),
         scene
       );
       cam.lowerRadiusLimit = Number(cameraZoomSlider.min ?? 0.6);
-      cam.upperRadiusLimit = Number(cameraZoomSlider.max ?? 2.8);
+      cam.upperRadiusLimit = Number(cameraZoomSlider.max ?? 2.4);
       cam.lowerBetaLimit = degToRad(safeLowerBetaDeg);
       cam.upperBetaLimit = degToRad(safeUpperBetaDeg);
       cam.wheelPrecision = 120;
@@ -302,7 +311,9 @@ function degToRad(degrees) {
       if (!cameraAlphaSlider || !cameraBetaSlider || !cameraZoomSlider) {
         return;
       }
-      const alphaDeg = clamp(Number(cameraAlphaSlider.value) || 0, 0, 360);
+      const alphaMin = Number(cameraAlphaSlider.min) || 0;
+      const alphaMax = Number(cameraAlphaSlider.max) || 360;
+      const alphaDeg = clamp(Number(cameraAlphaSlider.value) || 0, alphaMin, alphaMax);
       const betaMin = Number(cameraBetaSlider.min) || 0;
       const betaMax = Number(cameraBetaSlider.max) || 360;
       const betaDeg = clamp(Number(cameraBetaSlider.value) || 0, betaMin, betaMax);
@@ -312,7 +323,7 @@ function degToRad(degrees) {
       const zoom = clamp(
         Number(cameraZoomSlider.value) || 0,
         Number(cameraZoomSlider.min) || 0.6,
-        Number(cameraZoomSlider.max) || 2.8
+        Number(cameraZoomSlider.max) || 2.4
       );
 
       camera.alpha = degToRad(alphaDeg);


### PR DESCRIPTION
## Summary
- set the default camera orbit, pitch, and zoom to 90°, 45°, and 1.5 so the sliders start centered
- ensure camera initialization and updates respect the slider-provided ranges and new defaults

## Testing
- npm test

## Scenarios
- No scenario updates were necessary for this change


------
https://chatgpt.com/codex/tasks/task_e_69032cc60ed883338467668599f9de12