### PR TITLE
Ensure score board initializes after physics

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -473,6 +473,10 @@ function degToRad(degrees) {
 
     async function createScoreBoard() {
       setStatus('Creating score board…', '#2277cc');
+      if (!scene.getPhysicsEngine()) {
+        console.warn('[SpaceBall] ⚠ Physics engine not ready, skipping score board.');
+        return;
+      }
       // Compute board dimensions based on pocket layout
       const pockets = createPocketLayouts(geometry);
       const pocketCount = pockets.length;
@@ -564,8 +568,6 @@ function degToRad(degrees) {
       }
       setStatus('Score board ready ✔', '#118833');
     }
-
-    await step('Create score board', createScoreBoard);
 
     const physicsState = {
       plugin: null,
@@ -1009,6 +1011,9 @@ function degToRad(degrees) {
     await step('Enable physics', async () => {
       await initialisePhysics();
     });
+
+    // Now physics is active; create board safely
+    await step('Create score board', createScoreBoard);
 
     await step('Reset ball', async () => {
       resetBall();


### PR DESCRIPTION
## Summary
- delay the score board creation step until after Havok physics is enabled
- add a guard in `createScoreBoard` to log and exit if the physics engine is unavailable

## Testing
- not run (not requested)

## Scenarios
- Scenario: Move createScoreBoard step below physics initialization
- Scenario: Optional guard inside createScoreBoard

------
https://chatgpt.com/codex/tasks/task_e_690350e4d0208333a619a2784e640656