### PR TITLE
Align score board with rails

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -488,7 +488,8 @@ function degToRad(degrees) {
 
       // Position board so its front face sits at dropFloorZ and the rest extends deeper (negative z)
       const boardCenterY = (yMin + yMax) / 2;
-      const boardCenterZ = geometry.dropFloorZ - boardThickness / 2;
+      // Align board with the end of the rails (below them)
+      const boardCenterZ = -geometry.railDropLength - boardThickness / 2;
 
       // Wooden plate
       const board = MeshBuilder.CreateBox(


### PR DESCRIPTION
## Summary
- align the score board's z position with the rail ends so it sits below the rods

## Testing
- not run

## Scenarios
- docs/specs: Feature: Correct board and rod alignment according to design sketch

------
https://chatgpt.com/codex/tasks/task_e_690368a2afa08333a63e180e466ba076