### PR TITLE
Fix bootstrap rod helper initialization ordering

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -246,6 +246,49 @@ async function bootstrap() {
     let rightRailCollider;
     let railLength = 0;
 
+    const applyRodAngles = () => {
+      const progress = getCurrentBallProgress();
+      geometry.updateAngles({ thetaL: state.leftAngle, thetaR: state.rightAngle });
+      state.leftAngle = geometry.angles.leftDeg;
+      state.rightAngle = geometry.angles.rightDeg;
+      if (leftRail && rightRail) {
+        updateRailMeshes();
+      }
+      if (ball) {
+        positionBallOnRails(progress);
+      }
+      if (railSupports.left.length || railSupports.right.length) {
+        positionSupports();
+      }
+      updateDebugOverlayMeshes();
+    };
+
+    const applyRodAdjustables = () => {
+      const progress = getCurrentBallProgress();
+      geometry.updateAdjustables({ h: geometry.adjustable.h, d: geometry.adjustable.d });
+      geometry.updateAngles({ thetaL: state.leftAngle, thetaR: state.rightAngle });
+      state.leftAngle = geometry.angles.leftDeg;
+      state.rightAngle = geometry.angles.rightDeg;
+      pocketLayout = createPocketLayouts(geometry);
+      const heightCm = (geometry.adjustable.h / CM).toFixed(1);
+      const spacingCm = (geometry.adjustable.d / CM).toFixed(1);
+      if (rodHeightReadout) rodHeightReadout.textContent = `${heightCm} cm`;
+      if (rodSpacingReadout) rodSpacingReadout.textContent = `${spacingCm} cm`;
+      if (rodHeightSlider) {
+        rodHeightSlider.value = heightCm;
+        rodHeightSlider.setAttribute('aria-valuenow', heightCm);
+      }
+      if (rodSpacingSlider) {
+        rodSpacingSlider.value = spacingCm;
+        rodSpacingSlider.setAttribute('aria-valuenow', spacingCm);
+      }
+      if (!leftRail || !rightRail) return;
+      updateRailMeshes();
+      if (ball) positionBallOnRails(progress);
+      if (railSupports.left.length || railSupports.right.length) positionSupports();
+      updateDebugOverlayMeshes();
+    };
+
     await step('Initialize UI controls', async () => {
       if (!tiltSlider || !tiltReadout) {
         throw new Error('Tilt controls missing');
@@ -909,59 +952,6 @@ async function bootstrap() {
         }
       });
       overlayMeshes.points.slice(data.points.length).forEach((mesh) => mesh && (mesh.isVisible = false));
-    }
-
-    function applyRodAngles() {
-      const progress = getCurrentBallProgress();
-      geometry.updateAngles({ thetaL: state.leftAngle, thetaR: state.rightAngle });
-      state.leftAngle = geometry.angles.leftDeg;
-      state.rightAngle = geometry.angles.rightDeg;
-      if (leftRail && rightRail) {
-        updateRailMeshes();
-      }
-      if (ball) {
-        positionBallOnRails(progress);
-      }
-      if (railSupports.left.length || railSupports.right.length) {
-        positionSupports();
-      }
-      updateDebugOverlayMeshes();
-    }
-
-    function applyRodAdjustables() {
-      const progress = getCurrentBallProgress();
-      geometry.updateAdjustables({ h: geometry.adjustable.h, d: geometry.adjustable.d });
-      geometry.updateAngles({ thetaL: state.leftAngle, thetaR: state.rightAngle });
-      state.leftAngle = geometry.angles.leftDeg;
-      state.rightAngle = geometry.angles.rightDeg;
-      pocketLayout = createPocketLayouts(geometry);
-      const heightCm = (geometry.adjustable.h / CM).toFixed(1);
-      const spacingCm = (geometry.adjustable.d / CM).toFixed(1);
-      if (rodHeightReadout) {
-        rodHeightReadout.textContent = `${heightCm} cm`;
-      }
-      if (rodSpacingReadout) {
-        rodSpacingReadout.textContent = `${spacingCm} cm`;
-      }
-      if (rodHeightSlider) {
-        rodHeightSlider.value = heightCm;
-        rodHeightSlider.setAttribute('aria-valuenow', heightCm);
-      }
-      if (rodSpacingSlider) {
-        rodSpacingSlider.value = spacingCm;
-        rodSpacingSlider.setAttribute('aria-valuenow', spacingCm);
-      }
-      if (!leftRail || !rightRail) {
-        return;
-      }
-      updateRailMeshes();
-      if (ball) {
-        positionBallOnRails(progress);
-      }
-      if (railSupports.left.length || railSupports.right.length) {
-        positionSupports();
-      }
-      updateDebugOverlayMeshes();
     }
 
     function handlePadDown(side, pointerId, normalized) {


### PR DESCRIPTION
## Summary
- convert the rod helper functions to arrow functions so they close over the rail references after declaration
- guard adjustable updates until rails exist to avoid bootstrap crashes

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_69062e9182ac8333aa14b72b93aa23ec